### PR TITLE
changed LSF numended to ended condition

### DIFF
--- a/src/pipelines/canu/Grid_LSF.pm
+++ b/src/pipelines/canu/Grid_LSF.pm
@@ -54,7 +54,7 @@ sub configureLSF () {
     return   if (uc(getGlobal("gridEngine")) ne "LSF");
 
     setGlobalIfUndef("gridEngineSubmitCommand",              "bsub");
-    setGlobalIfUndef("gridEngineHoldOption",                 "-w \"numended\(\"WAIT_TAG\", \*\)\"");
+    setGlobalIfUndef("gridEngineHoldOption",                 "-w \"ended\(\"WAIT_TAG\"\)\"");
     setGlobalIfUndef("gridEngineHoldOptionNoArray",          "-w \"done\(\"WAIT_TAG\"\)\"");
     setGlobalIfUndef("gridEngineSyncOption",                 "-K");
     setGlobalIfUndef("gridEngineNameOption",                 "-J");


### PR DESCRIPTION
In testing LSF support, the use of numended(jobarray, *) throws an error "Job array does not exist...". Use of ended(jobarray) works - we always want to wait for them all anyway.