### PR TITLE
-p does not work for Build. Fix this by passing -p when it is set; previously ignored

### DIFF
--- a/src/meryl/meryl-build.C
+++ b/src/meryl/meryl-build.C
@@ -813,8 +813,8 @@ build(merylArgs *args) {
       fprintf(stderr, "Merge results.\n");
 
     int     argc = 0;
-    char  **argv = new char* [7 + 2 * args->segmentLimit];
-    bool   *arga = new bool  [7 + 2 * args->segmentLimit];
+    char  **argv = new char* [8 + 2 * args->segmentLimit];
+    bool   *arga = new bool  [8 + 2 * args->segmentLimit];
 
     arga[argc] = false;  argv[argc++] = "meryl-build-merge";
     arga[argc] = false;  argv[argc++] = "-M";
@@ -823,6 +823,11 @@ build(merylArgs *args) {
     if (args->beVerbose) {
       arga[argc] = false;
       argv[argc++] = "-v";
+    }
+
+    if (args->positionsEnabled) {
+      arga[argc] = false;
+      argv[argc++] = "-p";
     }
 
     for (uint32 i=0; i<args->segmentLimit; i++) {


### PR DESCRIPTION
meryl -B -p -s ... -o ... did not work. -p did nothing; no .mcpos was ever output.
This was because the positionsEnabled argument wasn't passed where it was supposed to be passed in meryl-build.C
With this change, passing -p into build will produce an .mcpos in the output directory