### PR TITLE
fixed crash when number of reads is < 40

### DIFF
--- a/src/overlapInCore/overlapInCorePartition.C
+++ b/src/overlapInCore/overlapInCorePartition.C
@@ -131,7 +131,7 @@ loadReadLengths(gkStore *gkp,
   fprintf(stderr, "     Reads        Bases      Reads        Bases      Reads        Bases\n");
   fprintf(stderr, "---------- ------------ ---------- ------------ ---------- ------------\n");
 
-  uint32  reportInterval = numReads / 40;
+  uint32  reportInterval = max(numReads / 40, (uint32)1);
 
   for (uint32 ii=1; ii<=numReads; ii++) {
     gkRead  *read = gkp->gkStore_getRead(ii);


### PR DESCRIPTION
in overlapInCorePartition.C