### PR TITLE
Fixing remaining typos found in documentation

### DIFF
--- a/documentation/source/commands/bogart.rst
+++ b/documentation/source/commands/bogart.rst
@@ -4,52 +4,52 @@ bogart
 ::
 
   usage: bogart -o outputName -O ovlStore -G gkpStore -T tigStore
-  
+
     -O         Mandatory path to an ovlStore.
     -G         Mandatory path to a gkpStore.
     -T         Mandatory path to a tigStore (can exist or not).
     -o prefix  Mandatory name for the output files
-  
+
     -B b       Target number of fragments per tigStore (consensus) partition
-  
+
   Algorithm Options
-  
+
     -gs        Genome size in bases.
-  
+
     -J         Join promiscuous unitigs using unused best edges.
-  
+
     -SR        Shatter repeats, don't rebuild.
     -R         Shatter repeats (-SR), then rebuild them
     -RL len    Force reads below 'len' bases to be singletons.
                  This WILL cause CGW to fail; diagnostic only.
-  
+
     -threads N Use N compute threads during repeat detection.
                  0 - use OpenMP default (default)
                  1 - use one thread
-  
+
   Overlap Selection - an overlap will be considered for use in a unitig under
                       the following conditions:
-  
+
     When constructing the Best Overlap Graph and Promiscuous Unitigs ('g'raph):
       -eg 0.020   no more than 0.020 fraction (2.0%) error   ** DEPRECATED **
-  
+
     When loading overlaps, an inflated maximum (to allow reruns with different error rates):
       -eM 0.05   no more than 0.05 fraction (5.0%) error in any overlap loaded into bogart
-                 the maximum used will ALWAYS be at leeast the maximum of the four error rates
-  
+                 the maximum used will ALWAYS be at least the maximum of the four error rates
+
     For all, the lower limit on overlap length
       -el 500     no shorter than 40 bases
-  
+
   Overlap Storage
-  
+
       -M gb    Use at most 'gb' gigabytes of memory for storing overlaps.
       -N num   Load at most 'num' overlaps per read.
-  
+
       -create  Only create the overlap graph, save to disk and quit.
       -save    Save the overlap graph to disk, and continue.
-  
+
   Debugging and Logging
-  
+
     -D <name>  enable logging/debugging for a specific component.
     -d <name>  disable logging/debugging for a specific component.
                  overlapScoring
@@ -62,7 +62,7 @@ bogart
                  intermediateUnitigs
                  setParentAndHang
                  stderr
-  
+
   No output prefix name (-o option) supplied.
   No gatekeeper store (-G option) supplied.
   No overlap store (-O option) supplied.

--- a/documentation/source/commands/canu.rst
+++ b/documentation/source/commands/canu.rst
@@ -4,7 +4,7 @@ canu
 ::
 
   -- Detected Java(TM) Runtime Environment '1.8.0_60' (from 'java').
-  
+
   usage: canu [-correct | -trim | -assemble] \
               [-s <assembly-specifications-file>] \
                -p <assembly-prefix> \
@@ -13,26 +13,26 @@ canu
                errorRate=0.X \
               [other-options] \
               [-pacbio-raw | -pacbio-corrected | -nanopore-raw | -nanopore-corrected] *fastq
-  
+
     By default, all three stages (correct, trim, assemble) are computed.
     To compute only a single stage, use:
       -correct  - generate corrected reads
       -trim     - generate trimmed reads
       -assemble - generate an assembly
-  
+
     The assembly is computed in the (created) -d <assembly-directory>, with most
     files named using the -p <assembly-prefix>.
-  
+
     The genome size is your best guess of the genome size of what is being assembled.
     It is used mostly to compute coverage in reads.  Fractional values are allowed: '4.7m'
     is the same as '4700k' and '4700000'
-  
+
     The errorRate is not used correctly (we're working on it).  Don't set it
     If you want to change the defaults, use the various utg*ErrorRate options.
-  
+
     A full list of options can be printed with '-options'.  All options
-    can be supplied in an optional sepc file.
-  
+    can be supplied in an optional spec file.
+
     Reads can be either FASTA or FASTQ format, uncompressed, or compressed
     with gz, bz2 or xz.  Reads are specified by the technology they were
     generated with:
@@ -40,10 +40,10 @@ canu
       -pacbio-corrected   <files>
       -nanopore-raw       <files>
       -nanopore-corrected <files>
-  
+
   Complete documentation at http://canu.readthedocs.org/en/latest/
-  
+
   ERROR:  Assembly name prefix not supplied with -p.
   ERROR:  Directory not supplied with -d.
   ERROR:  Required parameter 'genomeSize' is not set
-  
+

--- a/documentation/source/commands/overlapInCore.rst
+++ b/documentation/source/commands/overlapInCore.rst
@@ -6,7 +6,7 @@ overlapInCore
   * No kmer length supplied; -k needed!
   ERROR:  No output file name specified
   USAGE:  overlapInCore [options] <gkpStorePath>
-  
+
   -b <fn>     in contig mode, specify the output file
   -c          contig mode.  Use 2 frag stores.  First is
               for reads; second is for contigs
@@ -30,15 +30,15 @@ overlapInCore
   -u          allow only 1 overlap per oriented fragment pair
   -w          filter out overlaps with too many errors in a window
   -z          skip the hopeless check
-  
-  --maxerate <n>     only output overlaps with fraction <n> or less error (e.g., 0.06 == 6%)
+
+  --maxrate <n>      only output overlaps with fraction <n> or less error (e.g., 0.06 == 6%)
   --minlength <n>    only output overlaps of <n> or more bases
-  
+
   --hashbits n       Use n bits for the hash mask.
   --hashstrings n    Load at most n strings into the hash table at one time.
   --hashdatalen n    Load at most n bytes into the hash table at one time.
   --hashload f       Load to at most 0.0 < f < 1.0 capacity (default 0.7).
-  
+
   --maxreadlen n     For batches with all short reads, pack bits differently to
                      process more reads per batch.
                        all reads must be shorter than n
@@ -47,7 +47,7 @@ overlapInCore
                        maxreadlen 2048->hashstrings  524288 (default)
                        maxreadlen  512->hashstrings 2097152
                        maxreadlen  128->hashstrings 8388608
-  
+
   --readsperbatch n  Force batch size to n.
   --readsperthread n Force each thread to process n reads.
-  
+

--- a/documentation/source/commands/splitReads.rst
+++ b/documentation/source/commands/splitReads.rst
@@ -4,18 +4,18 @@ splitReads
 ::
 
   usage: splitReads -G gkpStore -O ovlStore -Ci input.clearFile -Co output.clearFile -o outputPrefix]
-  
+
     -G gkpStore    path to read store
     -O ovlStore    path to overlap store
-  
+
     -o name        output prefix, for logging
-  
+
     -t bgn-end     limit processing to only reads from bgn to end (inclusive)
-  
+
     -Ci clearFile  path to input clear ranges (NOT SUPPORTED)
-    -Co clearFile  path to ouput clear ranges
-  
+    -Co clearFile  path to output clear ranges
+
     -e erate       ignore overlaps with more than 'erate' percent error
-  
+
     -minlength l   reads trimmed below this many bases are deleted
-  
+

--- a/documentation/source/faq.rst
+++ b/documentation/source/faq.rst
@@ -15,7 +15,7 @@ What resources does Canu require for a bacterial genome assembly? A mammalian as
     resources.  It will request resources, for example, the number of compute threads to use, Based
     on the genome size being assembled. It will fail to even start if it feels there are
     insufficient resources available.
-    
+
     A typical bacterial genome can be assembled with 8GB memory in a few CPU hours - around an hour
     on 8 cores.  It is possible, but not allowed by default, to run with only 4GB memory.
 
@@ -28,7 +28,7 @@ What resources does Canu require for a bacterial genome assembly? A mammalian as
     1TB memory.  We develop and test (mostly bacteria, yeast and drosophila) on laptops and desktops
     with 4 to 12 compute threads and 16GB to 64GB memory.
 
-    
+
 How do I run Canu on my SLURM / SGE / PBS / LSF / Torque system?
 -------------------------------------
     Canu will detect and configure itself to use on most grids. You can supply your own grid
@@ -44,7 +44,7 @@ How do I run Canu on my SLURM / SGE / PBS / LSF / Torque system?
     can pass grid-specific parameters to the submit commands used; see
     `Issue #756 <https://github.com/marbl/canu/issues/756>`_ for Slurm and SGE examples.
 
-    
+
 My run stopped with the error ``'Failed to submit batch jobs'``
 -------------------------------------
 
@@ -52,7 +52,7 @@ My run stopped with the error ``'Failed to submit batch jobs'``
     compute host, ``qsub/bsub/sbatch/etc`` must be available and working. You can test this by
     starting an interactive compute session and running the submit command manually (e.g. ``qsub``
     on SGE, ``bsub`` on LSF, ``sbatch`` on SLURM).
-    
+
     If this is not the case, Canu **WILL NOT** work on your grid. You must then set
     ``useGrid=false`` and run on a single machine. Alternatively, you can run Canu with
     ``useGrid=remote`` which will stop at every submit command, list what should be submitted. You
@@ -66,7 +66,7 @@ What parameters should I use for my reads?
     Canu is designed to be universal on a large range of PacBio (C2, P4-C2, P5-C3, P6-C4) and Oxford
     Nanopore (R6 through R9) data.  Assembly quality and/or efficiency can be enhanced for specific
     datatypes:
-    
+
     **Nanopore R7 1D** and **Low Identity Reads**
        With R7 1D sequencing data, and generally for any raw reads lower than 80% identity, five to
        ten rounds of error correction are helpful::
@@ -92,17 +92,17 @@ What parameters should I use for my reads?
        with ``correctedErrorRate=0.120``
 
     **Early PacBio Sequel**
-       Based on one publically released *A. thaliana* `dataset
+       Based on one publicly released *A. thaliana* `dataset
        <http://www.pacb.com/blog/sequel-system-data-release-arabidopsis-dataset-genome-assembly/>`_,
        and a few more recent mammalian genomes, slightly increase the maximum allowed difference from the default of 4.5% to 6.5% with
-       ``correctedErrorRate=0.065 corMhapSensitivity=normal``.  
-   
+       ``correctedErrorRate=0.065 corMhapSensitivity=normal``.
+
    **Nanopore R9 large genomes**
        Due to some systematic errors, the identity estimate used by Canu for correction can be an
        over-estimate of true error, inflating runtime. For recent large genomes (>1gbp) with more
        than 30x coverage, we've used ``'corMhapOptions=--threshold 0.8 --num-hashes
        512 --ordered-sketch-size 1000 --ordered-kmer-size 14'``. This is not needed for below 30x
-       coverage. 
+       coverage.
 
 
 Can I assemble RNA sequence data?
@@ -124,9 +124,9 @@ My assembly continuity is not good, how can I improve it?
     bases output by the correction step.  This is logged in the stdout of Canu or in
     canu-scripts/canu.*.out if you are running in a grid environment. For example on `a
     haploid H. sapiens <https://www.ncbi.nlm.nih.gov/Traces/study/?acc=SAMN02744161>`_ sample:
-    
+
     ::
-    
+
        -- BEGIN TRIMMING
        --
        ...
@@ -171,13 +171,13 @@ What parameters can I tweak?
 
     - ``corMinCoverage``, loosely, controls the quality of the corrected reads.  It is the coverage
       in evidence reads that is needed before a (portion of a) corrected read is reported.
-      Corrected reads are generated as a consensus of other reads; this is just the minimum ocverage
+      Corrected reads are generated as a consensus of other reads; this is just the minimum coverage
       needed for the consensus sequence to be reported.  The default is based on input read
       coverage: 0x coverage for less than 30X input coverage, and 4x coverage for more than that.
 
     For assembly:
 
-    - ``utgOvlErrorRate`` is essientially a speed optimization.  Overlaps above this error rate are
+    - ``utgOvlErrorRate`` is essentially a speed optimization.  Overlaps above this error rate are
       not computed.  Setting it too high generally just wastes compute time, while setting it too
       low will degrade assemblies by missing true overlaps between lower quality reads.
 
@@ -192,25 +192,25 @@ What parameters can I tweak?
 
     For polyploid genomes:
 
-        Generally, there's a couple of ways of dealing with the ploidy. 
-    
+        Generally, there's a couple of ways of dealing with the ploidy.
+
         1) **Avoid collapsing the genome** so you end up with double (assuming diploid) the genome
            size as long as your divergence is above about 2% (for PacBio data). Below this
            divergence, you'd end up collapsing the variations. We've used the following parameters
            for polyploid populations (PacBio data):
 
            ``corOutCoverage=200 "batOptions=-dg 3 -db 3 -dr 1 -ca 500 -cp 50"``
-    
+
            This will output more corrected reads (than the default 40x). The latter option will be
            more conservative at picking the error rate to use for the assembly to try to maintain
            haplotype separation. If it works, you'll end up with an assembly >= 2x your haploid
            genome size. Post-processing using gene information or other synteny information is
-           required to remove redunancy from this assembly.
+           required to remove redundancy from this assembly.
 
         2) **Smash haplotypes together** and then do phasing using another approach (like HapCUT2 or
            whatshap or others). In that case you want to do the opposite, increase the error rates
            used for finding overlaps:
-   
+
            ``corOutCoverage=200 correctedErrorRate=0.15``
 
            When trimming, reads will be trimmed using other reads in the same
@@ -221,7 +221,7 @@ What parameters can I tweak?
 
         The basic idea is to use all data for assembly rather than just the longest as default. The
         parameters we've used recently are:
-        
+
           ``corOutCoverage=10000 corMhapSensitivity=high corMinCoverage=0 redMemory=32 oeaMemory=32 batMemory=200``
 
     For low coverage:
@@ -291,15 +291,15 @@ My circular element is duplicated/has overlap?
 
     An alternative is to run MUMmer to get self-alignments on the contig and use those trim
     points. For example, assuming the circular element is in ``tig00000099.fa``. Run::
-    
+
       nucmer -maxmatch -nosimplify tig00000099.fa tig00000099.fa
       show-coords -lrcTH out.delta
-    
+
     to find the end overlaps in the tig. The output would be something like::
-    
+
       1	1895	48502	50400	1895	1899	99.37	50400	50400	3.76	3.77	tig00000001	tig00000001
       48502	50400	1	1895	1899	1895	99.37	50400	50400	3.77	3.76	tig00000001	tig00000001
-    
+
     means trim to 1 to 48502. There is also an alternate `writeup
     <https://github.com/PacificBiosciences/Bioinformatics-Training/wiki/Circularizing-and-trimming>`_.
 
@@ -320,7 +320,7 @@ How can I send data to you?
 -------------------------------------
    FTP to ftp://ftp.cbcb.umd.edu/incoming/sergek.  This is a write-only location that only the Canu
    developers can see.
-   
+
    Here is a quick walk-through using a command-line ftp client (should be available on most Linux
    and OSX installations). Say we want to transfer a file named ``reads.fastq``. First, run ``ftp
    ftp.cbcb.umd.edu``, specify ``anonymous`` as the user name and hit return for password

--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -2,10 +2,10 @@
 ..
  introduction
   what this is
- 
+
  quick start
   one PacBio SMRT cell from ecoli
- 
+
  pipeline (not reference, designed to be read through)
   overview
    introduce modular pipeline
@@ -13,16 +13,16 @@
   read correction
   read trimming
   unitig construction
- 
+
   local vs grid mode
- 
- 
+
+
  canu option reference
   each option, in detail, grouped by function
- 
+
  canu executable reference
   each binary, in detail, alphabetical
- 
+
  option index (alphabetical)
 
  history
@@ -43,7 +43,7 @@ Canu
 
 
 `Canu <http://github.com/marbl/canu>`_ is a fork of the Celera Assembler designed for high-noise single-molecule sequencing (such as
-the PacBio RSII or Oxford Nanopore MinION). 
+the PacBio RSII or Oxford Nanopore MinION).
 
 Publication
 ===========
@@ -70,6 +70,6 @@ Learn
 *  :ref:`Canu tutorial             <tutorial>`   - a gentle introduction to the complexities of canu.
 *  :ref:`Canu pipeline             <pipeline>`   - what, exactly, is canu doing, anyway?
 
-*  :ref:`Canu Parameter Reference  <parameter-reference>` - all the paramters, grouped by function.
+*  :ref:`Canu Parameter Reference  <parameter-reference>` - all the parameters, grouped by function.
 *  :ref:`Canu Command Reference    <command-reference>` - all the commands that canu runs for you.
 *  :ref:`Canu History              <history>` - the history of the Canu project.

--- a/documentation/source/parameter-reference.rst
+++ b/documentation/source/parameter-reference.rst
@@ -54,7 +54,7 @@ correctedErrorRate <float=unset>
   <correctedErrorRate>` slightly, by 1% or so.
 
   For high-coverage datasets (more than 60X), we recommend decreasing :ref:`correctedErrorRate
-  <correctedErrorRate>` slighly, by 1% or so.
+  <correctedErrorRate>` slightly, by 1% or so.
 
   Raising the :ref:`correctedErrorRate <correctedErrorRate>` will increase run time.  Likewise,
   decreasing :ref:`correctedErrorRate <correctedErrorRate>` will decrease run time, at the risk of
@@ -154,16 +154,16 @@ stopOnReadQuality <string=true>
   ::
 
    Gatekeeper detected potential problems in your input reads.
-   
+
    Please review the logging in files:
      /assembly/godzilla/asm.gkpStore.BUILDING.err
      /assembly/godzilla/asm.gkpStore.BUILDING/errorLog
-   
+
    If you wish to proceed, rename the store with the following command and restart canu.
-   
+
      mv /assembly/godzilla/asm.gkpStore.BUILDING \
         /assembly/godzilla/asm.gkpStore.ACCEPTED
-   
+
    Option stopOnReadQuality=false skips these checks.
 
   The missing reads could be too short (decrease :ref:`minReadLength <minReadLength>` to include
@@ -258,7 +258,7 @@ saveOverlaps <boolean=false>
   longer needed..  This is recommended in nearly every case.
 
   If set to 'stores', the raw overlapper outputs are removed, but all of the overlap stores are
-  retained.  The overlap stores capture all the critical informatoion in the raw outputs and the raw
+  retained.  The overlap stores capture all the critical information in the raw outputs and the raw
   outputs are redundant and unwieldy.  Retaining the overlap stores can allow one to 'back up' and
   redo a step, but this is generally not useful unless one is familiar with the algorithms.
 
@@ -268,7 +268,7 @@ saveOverlaps <boolean=false>
 saveReadCorrections <boolean=false>.
   If set, do not remove raw corrected read output from correction/2-correction. Normally, this
   output is removed once the corrected reads are generated.
-  
+
 saveIntermediates <boolean=false>
   If set, do not remove intermediate outputs.  Normally, intermediate files are removed
   once they are no longer needed.
@@ -299,7 +299,7 @@ on the option: 'cor' for read correction, 'obt' for read trimming ('overlap base
 read correction to the 'ovl' algorithm.
 
 {prefix}Overlapper <string=see-below>
-  Specify which overlap algorith, 'mhap' or 'ovl' or 'minimap'.  The default is to use 'mhap' for
+  Specify which overlap algorithm, 'mhap' or 'ovl' or 'minimap'.  The default is to use 'mhap' for
   'cor' and 'ovl' for both 'obt' and 'utg'.
 
 Overlapper Configuration, ovl Algorithm
@@ -328,7 +328,7 @@ Overlapper Configuration, ovl Algorithm
   Amount of sequence (bp to load into the overlap hash table.
 
 {prefix}OvlHashLoad <integer=unset>
-  Maximum hash table load.  If set too high, table lookups are inefficent; if too low, search
+  Maximum hash table load.  If set too high, table lookups are inefficient; if too low, search
   overhead dominates run time.
 
 {prefix}OvlMerDistinct <integer=unset>
@@ -399,7 +399,7 @@ ovsMemory <float>
 ovsMethod <string="sequential">
   Two construction algorithms are supported.  The 'sequential' method uses a single data stream, and
   is faster for small and moderate size assemblies.  The 'parallel' method uses multiple compute
-  nodes and can be faster (depending on your network disk bandwitdh) for moderate and large
+  nodes and can be faster (depending on your network disk bandwidth) for moderate and large
   assemblies.
 
   The parallel method is selected for genomes larger than 1 Gbp, but only when Canu runs in grid
@@ -445,14 +445,14 @@ Grid Engine Support
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Canu directly supports most common grid scheduling systems.  Under normal use, Canu will query the
-system for grid support, congigure itself for the machines available in the grid, then submit itself
+system for grid support, configure itself for the machines available in the grid, then submit itself
 to the grid for execution.  The Canu pipeline is a series of about a dozen steps that alternate
-between embarassingly parallel computations (e.g., overlap computation) and sequential bookkeeping
+between embarrassingly parallel computations (e.g., overlap computation) and sequential bookkeeping
 steps (e.g., checking if all overlap jobs finished).  This is entirely managed by Canu.
 
 Canu has first class support for the various schedulers derived from Sun Grid Engine (Univa, Son of
 Grid Engine) and the Simple Linux Utility for Resource Management (SLURM), meaning that the
-devlopers have direct access to these systems.  Platform Computing's Load Sharing Facility (LSF) and
+developers have direct access to these systems.  Platform Computing's Load Sharing Facility (LSF) and
 the various schedulers derived from the Portable Batch System (PBS, Torque and PBSPro) are supported
 as well, but without developer access bugs do creep in.  As of Canu v1.5, support seems stable and
 working.
@@ -529,7 +529,7 @@ To run on the grid, each stage needs to be configured - to tell the grid how man
 Some support for this is automagic (for example, overlapInCore and mhap know how to do this), others need to be manually configured.
 Yes, it's a problem, and yes, we want to fix it.
 
-The gridOptions* parameters supply grid-specific opitons to the grid submission command.
+The gridOptions* parameters supply grid-specific options to the grid submission command.
 
 gridOptions <string=unset>
   Grid submission command options applied to all grid jobs
@@ -572,7 +572,7 @@ Algorithm Selection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Several algorithmic components of canu can be disabled, based on the type of the reads being
-assebmled, the type of processing desired, or the amount of comput resources available.  Overlap
+assembled, the type of processing desired, or the amount of compute resources available.  Overlap
 
 enableOEA <boolean=true>
   Do overlap error adjustment - comprises two steps: read error detection (RED and overlap error adjustment (OEA
@@ -657,7 +657,7 @@ correction.
 .. _maxThreads:
 
 The 'minMemory', 'maxMemory', 'minThreads' and 'maxThreads' options will apply to all jobs, and
-can be used to artifically limit canu to a portion of the current machine.  In the overlapper
+can be used to artificially limit canu to a portion of the current machine.  In the overlapper
 example above, setting maxThreads=4 would result in two concurrent jobs instead of four.
 
 
@@ -704,15 +704,15 @@ cnsPartitions
   Compute conseus by splitting the tigs into N partitions.
 
 cnsPartitionMin
-  Don't make a paritition with fewer than N reads
+  Don't make a partition with fewer than N reads
 
 cnsMaxCoverage
   Limit unitig consensus to at most this coverage.
- 
+
 .. _cnsErrorRate:
 
 cnsErrorRate
-  Inform the consensus genration algorithm of the amount of difference it should expect in a
+  Inform the consensus generation algorithm of the amount of difference it should expect in a
   read-to-read alignment.  Typically set to :ref:`utgOvlErrorRate <utgOvlErrorRate>`.  If set too
   high, reads could be placed in an incorrect location, leading to errors in the consensus sequence.
   If set too low, reads could be omitted from the consensus graph (or multialignment, depending on
@@ -773,7 +773,7 @@ Output Filtering
 .. _contigFilter:
 
 contigFilter <minReads, integer=2> <minLength, integer=0> <singleReadSpan, float=1.0> <lowCovSpan, float=0.5> <lowCovDepth, integer=5>
-  A contig that meeds any of the following conditions is flagged as 'unassembled' and removed from
+  A contig that needs any of the following conditions is flagged as 'unassembled' and removed from
   further consideration:
     - fewer than minReads reads (default 2)
     - shorter than minLength bases (default 0)
@@ -781,5 +781,5 @@ contigFilter <minReads, integer=2> <minLength, integer=0> <singleReadSpan, float
     - more than lowCovSpan fraction of the contig is at coverage below lowCovDepth (defaults 0.5, 5)
   This filtering is done immediately after initial contigs are formed, before potentially
   incorrectly spanned repeats are detected.  Initial contigs that incorrectly span a repeat can be
-  split into multiple conitgs; none of these new contigs will be flagged as 'unassembled', even if
+  split into multiple contigs; none of these new contigs will be flagged as 'unassembled', even if
   they are a single read.

--- a/documentation/source/quick-start.rst
+++ b/documentation/source/quick-start.rst
@@ -25,7 +25,7 @@ available and are reasonable for the size of your assembly.  Memory and processo
 limited with with parameters :ref:`maxMemory <maxMemory>` and :ref:`maxThreads <maxThreads>`.  See section :ref:`execution`
 for more details.
 
-Canu will automaticall take full advantage of any LSF/PBS/PBSPro/Torque/Slrum/SGE grid available,
+Canu will automatically take full advantage of any LSF/PBS/PBSPro/Torque/Slrum/SGE grid available,
 even submitting itself for execution.  Canu makes heavy use of array jobs and requires job
 submission from compute nodes, which are sometimes not available or allowed.  Canu option
 ``useGrid=false`` will restrict Canu to using only the current machine, while option
@@ -77,7 +77,7 @@ For Nanopore::
 
 
 Output and intermediate files will be in directories 'ecoli-pacbio' and 'ecoli-nanopore',
-respectively.  Intermeditate files are written in directories 'correction', 'trimming' and
+respectively.  Intermediate files are written in directories 'correction', 'trimming' and
 'unitigging' for the respective stages.  Output files are named using the '-p' prefix, such as
 'ecoli.contigs.fasta', 'ecoli.contigs.gfa', etc.  See section :ref:`outputs` for more details on
 outputs (intermediate files aren't documented).
@@ -92,7 +92,7 @@ file::
 
  curl -L -o mix.tar.gz http://gembox.cbcb.umd.edu/mhap/raw/ecoliP6Oxford.tar.gz
  tar xvzf mix.tar.gz
- 
+
  canu \
   -p ecoli -d ecoli-mix \
   genomeSize=4.8m \
@@ -105,7 +105,7 @@ Correct, Trim and Assemble, Manually
 
 Sometimes, however, it makes sense to do the three top-level tasks by hand.  This would allow trying
 multiple unitig construction parameters on the same set of corrected and trimmed reads, or skipping
-trimming and assembly if you only want correced reads.
+trimming and assembly if you only want corrected reads.
 
 We'll use the PacBio reads from above.  First, correct the raw reads::
 
@@ -145,7 +145,7 @@ Assembling Low Coverage Datasets
 
 We claimed Canu works down to 20X coverage, and we will now assemble `a 20X subset of S. cerevisae
 <http://gembox.cbcb.umd.edu/mhap/raw/yeast_filtered.20x.fastq.gz>`_ (215 MB).  When assembling, we
-adjust :ref:`correctedErrorRate <correctedErrorRate>` to accomodate the slightly lower
+adjust :ref:`correctedErrorRate <correctedErrorRate>` to accommodate the slightly lower
 quality corrected reads::
 
  curl -L -o yeast.20x.fastq.gz http://gembox.cbcb.umd.edu/mhap/raw/yeast_filtered.20x.fastq.gz

--- a/documentation/source/tutorial.rst
+++ b/documentation/source/tutorial.rst
@@ -12,7 +12,7 @@ uniquely-assemblable contigs, unitigs.  Canu owes lots of it design and code to
 `celera-assembler <Celera Assembler>`_.
 
 Canu can be run using hardware of nearly any shape or size, anywhere from laptops to computational
-grids with thousands of nodes.  Obviouisly, larger assemblies will take a long time to compute on
+grids with thousands of nodes.  Obviously, larger assemblies will take a long time to compute on
 laptops, and smaller assemblies can't take advantage of hundreds of nodes, so what is being
 assembled plays some part in determining what hardware can be effectively used.
 
@@ -223,14 +223,14 @@ confidence you can figure out the missing values:
 ==============  =============
 Fraction Error  Percent Error
 ==============  =============
-0.01            1%           
-0.02            2%           
-0.03            3%           
-.               .            
-.               .            
-0.12            12%          
-.               .            
-.               .            
+0.01            1%
+0.02            2%
+0.03            3%
+.               .
+.               .
+0.12            12%
+.               .
+.               .
 ==============  =============
 
 Canu error rates always refer to the percent difference in an alignment of two reads, not the
@@ -320,7 +320,7 @@ Ovl Overlapper Parameters
   how many bases to reads to include in the hash table; directly controls process size
 <tag>ovlRefBlockSize
   how many reads to compute overlaps for in one process; directly controls process time
-<tag>ovlRefBlockLength 
+<tag>ovlRefBlockLength
  same, but use 'bases in reads' instead of 'number of reads'
 <tag>ovlHashBits
   size of the hash table (SHOULD BE REMOVED AND COMPUTED, MAYBE TWO PASS)
@@ -390,7 +390,7 @@ Minimap Overlapper Parameters
 <tag>MMapMerSize
   Use k-mers of this size for detecting overlaps
 
-Minimap also will ignore high-frequency minimzers, but it's selection of frequent is not exposed.
+Minimap also will ignore high-frequency minimizers, but it's selection of frequent is not exposed.
 
 .. _outputs:
 


### PR DESCRIPTION
Ran spellchecker over documentation and make corrections where possible.

Note that also in a few cases my IDE was stripping trailing whitespace, which I have also committed as it fixed some of the formatting. I use PyCharm which validates the RestructuredText.