### PR TITLE
Additional updates for DNAnexus cloud opperations

### DIFF
--- a/src/dx-canu/dxapp.json
+++ b/src/dx-canu/dxapp.json
@@ -58,8 +58,10 @@
         "hours": 72
       }
     },
+    "restartableEntryPoints": "all", 
     "interpreter": "bash",
     "file": "src/canu.sh",
+    "executionPolicy": {"restartOn": {"*": 2}},
     "distribution": "Ubuntu",
     "release": "14.04"
   },
@@ -80,7 +82,7 @@
     "aws:us-east-1": {
       "systemRequirements": {
         "*": {
-          "instanceType": "mem3_ssd1_x32"
+          "instanceType": "mem1_ssd2_x36"
         }
       }
     }

--- a/src/dx-canu/resources/bin/dx-get-instance-info.py
+++ b/src/dx-canu/resources/bin/dx-get-instance-info.py
@@ -68,7 +68,8 @@ def output_region_compatible_instances(instance_type_to_resources):
         return (mem, storage, int(cores[1:]))
 
     sorted_keys = sorted(instance_type_to_resources.keys(), key=instance_compare)
-    print 'Instance Type\tMemory (GB)\tStorage (GB)\tCores'
+    #print 'Instance Type\tMemory (GB)\tStorage (GB)\tCores'
+    print 'Name\tMemory_GB\tStorage_GB\tCPU_Cores'
     for inst_type in sorted_keys:
         resource_dict = instance_type_to_resources[inst_type]
         print '{}\t{}\t{}\t{}'.format(inst_type, resource_dict['memory_gb'], resource_dict['storage_gb'], resource_dict['cores'])

--- a/src/pipelines/canu/Grid_Cloud.pm
+++ b/src/pipelines/canu/Grid_Cloud.pm
@@ -211,6 +211,7 @@ sub fetchFile ($) {
     make_path(dirname($file));
 
     if    (isOS() eq "DNANEXUS") {
+        runCommandSilently(".", "dirname \"$file\" | xargs -n 1 mkdir -p", 1);
         runCommandSilently(".", "$client download --output \"$file\" \"$pr:$ns/$file\"", 1);
     }
 }
@@ -242,6 +243,7 @@ sub fetchFileShellCode ($$$) {
         $code .= "${indent}if [ ! -e $dots/$path/$file ] ; then\n";
         $code .= "${indent}  mkdir -p $dots/$path\n";
         $code .= "${indent}  cd       $dots/$path\n";
+        $code .= "${indent}  dirname \"$file\" | xargs -n 1 mkdir -p \n";
         $code .= "${indent}  $client download --output \"$file\" \"$pr:$ns/$path/$file\"\n";
         $code .= "${indent}  cd -\n";
         $code .= "${indent}fi\n";

--- a/src/pipelines/canu/Grid_DNANexus.pm
+++ b/src/pipelines/canu/Grid_DNANexus.pm
@@ -44,7 +44,7 @@ use canu::Grid "formatAllowedResources";
 sub buildAvailableNodeList() {
     my %hosts;
 
-    open(F, "dx-get-instance-info.py -p -s 64 | iconv -c -f UTF-8 -t ASCII//TRANSLIT | ");
+    open(F, "dx-get-instance-info.py -p -s 128 | iconv -c -f UTF-8 -t ASCII//TRANSLIT | ");
 
     my $cpuIdx = 0;
     my $memIdx = 0;

--- a/src/pipelines/canu/Grid_DNANexus.pm
+++ b/src/pipelines/canu/Grid_DNANexus.pm
@@ -52,10 +52,10 @@ sub buildAvailableNodeList() {
 
     while (<F>) {
        if (m/Name\s+|\s+Memory_GB/) {
-          my @h = split '\|';
+          my @h = split '\t';
 
           for (my $ii=0; ($ii < scalar(@h)); $ii++) {
-             $cpuIdx  = $ii  if ($h[$ii] eq "CPU_Cores");
+             $cpuIdx  = $ii  if ($h[$ii] eq "CPU_Cores\n");
              $memIdx  = $ii  if ($h[$ii] eq "Memory_GB");
              $nameIdx = $ii  if ($h[$ii] =~ m/Name/);
           }
@@ -64,7 +64,7 @@ sub buildAvailableNodeList() {
     }
 
     while (<F>) {
-        my @v = split '\|', $_;
+        my @v = split '\t', $_;
 
         my $cpus = $v[$cpuIdx];
         my $mem  = $v[$memIdx] * 0.85; # the machines don't have swap so save some space for OS overhead


### PR DESCRIPTION
This PR fixes a few additional issues that were discovered while testing on larger data sets.

1. In the DNAnexus app, set it so that sub-jobs are restartable so that if a cloud worker goes down, it will attempt to restart rather than fail the entire job-tree.
2. There was an issue in parsing the output of the new script I provided to describe available instance types.  That has been fixed.
3. Set it so that it will request an instance with a minimum of 128 GB storage (some instances have as little as 32 GB of storage and will frequently run out of disk).
4. When downloading files, I encountered an issue where it was downloading to this/folder/structure/my_file.txt but the folder structure didn't already exist, so the download silently failed.  I updated the script to create the desired folder structure before the download.