### PR TITLE
Add SLURM control arguments

### DIFF
--- a/src/pipelines/canu/Defaults.pm
+++ b/src/pipelines/canu/Defaults.pm
@@ -832,6 +832,16 @@ sub setDefaults () {
     setDefault("gridEngineArraySubmitID",             undef, "Grid engine configuration, not documented");
     setDefault("gridEngineJobID",                     undef, "Grid engine configuration, not documented");
 
+    #####  Slurm-specific parameters for controlling the number of
+    #####  cores / tasks dispatched per step or globally (WIP)
+
+    setDefault( 'slurmCormhapCoreLimit', undef, 'Maximum number of cores allocated for MHAP pre-computing and alignment within the correction phase' );
+    setDefault( 'slurmOvbCoreLimit', undef, 'Maximum number of single-core tasks dispatched for the ovlStore bucketizing step within the trimming phase' );
+    setDefault( 'slurmOvsCoreLimit', undef, 'Maximum number of single-core tasks dispatched for the ovlStore sorting step within the trimming phase' );
+    setDefault( 'slurmRedCoreLimit', undef, 'Maximum number of cores allocated for read error detection within the unitigging phase' );
+    setDefault( 'slurmArrayTaskLimit', undef, 'Maximum number of tasks permitted for each step throughout assembly' );
+    setDefault( 'slurmArrayCoreLimit', undef, 'Maximum number of cores allocated for each step throughout assembly' );
+
     #####  Grid Engine Pipeline
 
     setDefault("useGrid", 1, "If 'true', enable grid-based execution; if 'false', run all jobs on the local machine; if 'remote', create jobs for grid execution but do not submit; default 'true'");

--- a/src/pipelines/canu/Execution.pm
+++ b/src/pipelines/canu/Execution.pm
@@ -996,7 +996,7 @@ sub buildGridJob ($$$$$$$$$) {
     my $jobNameT               = makeUniqueJobName($jobType, $asm);
 
     my ($jobName,  $jobOff)    = buildGridArray($jobNameT, $bgnJob, $endJob, getGlobal("gridEngineArrayName"));
-    my ( $arrayOpt, $arrayOff ) = buildGridArray( $jobNameT, $bgnJob, $endJob, getGlobal( "gridEngineArrayOption" ), $thr );
+    my ($arrayOpt, $arrayOff) = buildGridArray( $jobNameT, $bgnJob, $endJob, getGlobal( "gridEngineArrayOption" ), $thr );
 
     my $outputOption           = buildOutputOption($path, $script);
 

--- a/src/pipelines/canu/Execution.pm
+++ b/src/pipelines/canu/Execution.pm
@@ -996,7 +996,7 @@ sub buildGridJob ($$$$$$$$$) {
     my $jobNameT               = makeUniqueJobName($jobType, $asm);
 
     my ($jobName,  $jobOff)    = buildGridArray($jobNameT, $bgnJob, $endJob, getGlobal("gridEngineArrayName"));
-    my ($arrayOpt, $arrayOff) = buildGridArray( $jobNameT, $bgnJob, $endJob, getGlobal( "gridEngineArrayOption" ), $thr );
+    my ($arrayOpt, $arrayOff) = buildGridArray($jobNameT, $bgnJob, $endJob, getGlobal("gridEngineArrayOption"), $thr);
 
     my $outputOption           = buildOutputOption($path, $script);
 

--- a/src/pipelines/canu/Execution.pm
+++ b/src/pipelines/canu/Execution.pm
@@ -342,6 +342,10 @@ sub skipStage ($$@) {
 sub getInstallDirectory () {
     my $installDir = $FindBin::RealBin;
 
+    if ($installDir =~ m!^(.*)/\w+-\w+/bin$!) {
+        $installDir = $1;
+    }
+
     return($installDir);
 }
 

--- a/src/pipelines/canu/Execution.pm
+++ b/src/pipelines/canu/Execution.pm
@@ -342,10 +342,6 @@ sub skipStage ($$@) {
 sub getInstallDirectory () {
     my $installDir = $FindBin::RealBin;
 
-    if ($installDir =~ m!^(.*)/\w+-\w+/bin$!) {
-        $installDir = $1;
-    }
-
     return($installDir);
 }
 
@@ -773,8 +769,8 @@ sub submitScript ($$) {
 
 
 
-sub buildGridArray ($$$$) {
-    my ($name, $bgn, $end, $opt) = @_;
+sub buildGridArray (@) {
+    my ( $name, $bgn, $end, $opt, $thr ) = @_;
     my  $off = 0;
 
     #  In some grids (SGE)   this is the maximum size of an array job.
@@ -812,8 +808,42 @@ sub buildGridArray ($$$$) {
         $off = "-F \"$off\"";
     }
 
-    $opt =~ s/ARRAY_NAME/$name/g;        #  Replace ARRAY_NAME with 'job name'
-    $opt =~ s/ARRAY_JOBS/$bgn-$end/g;    #  Replace ARRAY_JOBS with 'bgn-end'
+    if( $opt =~ m/(ARRAY_NAME)/ )
+    {
+	$opt =~ s/$1/$name/; # Replace ARRAY_NAME with 'job name'
+    }
+    elsif( $opt =~ m/(ARRAY_JOBS)/ )
+    {
+	$opt =~ s/$1/$bgn-$end/; # Replace ARRAY_JOBS with 'bgn-end'
+
+	if( lc( getGlobal( 'gridEngine' ) ) eq 'slurm' && $end > 1 )
+	{
+	    if( $name =~ m/^cormhap_/i && defined getGlobal( 'slurmCormhapCoreLimit' ) )
+	    {
+		$opt .= '%' . int( getGlobal( 'slurmCormhapCoreLimit' ) / $thr );
+	    }
+	    elsif( $name =~ m/^ovb_/i && defined getGlobal( 'slurmOvbCoreLimit' ) )
+	    {
+		$opt .= '%' . getGlobal( 'slurmOvbCoreLimit' );
+	    }
+	    elsif( $name =~ m/^ovs_/i && defined getGlobal( 'slurmOvsCoreLimit' ) )
+	    {
+		$opt .= '%' . getGlobal( 'slurmOvsCoreLimit' );
+	    }
+	    elsif( $name =~ m/^red_/i && defined getGlobal( 'slurmRedCoreLimit' ) )
+	    {
+		$opt .= '%' . int( getGlobal( 'slurmRedCoreLimit' ) / $thr );
+	    }
+	    elsif( defined getGlobal( 'slurmArrayTaskLimit' ) )
+	    {
+		$opt .= '%' . getGlobal( 'slurmArrayTaskLimit' );
+	    }
+	    elsif( defined getGlobal( 'slurmArrayCoreLimit' ) )
+	    {
+		$opt .= '%' . int( getGlobal( 'slurmArrayCoreLimit' ) / $thr );
+	    }
+	}
+    }
 
     return($opt, $off);
 }
@@ -962,7 +992,7 @@ sub buildGridJob ($$$$$$$$$) {
     my $jobNameT               = makeUniqueJobName($jobType, $asm);
 
     my ($jobName,  $jobOff)    = buildGridArray($jobNameT, $bgnJob, $endJob, getGlobal("gridEngineArrayName"));
-    my ($arrayOpt, $arrayOff)  = buildGridArray($jobNameT, $bgnJob, $endJob, getGlobal("gridEngineArrayOption"));
+    my ( $arrayOpt, $arrayOff ) = buildGridArray( $jobNameT, $bgnJob, $endJob, getGlobal( "gridEngineArrayOption" ), $thr );
 
     my $outputOption           = buildOutputOption($path, $script);
 


### PR DESCRIPTION

Aurash Mohaimani and I developed and extensively tested these new parameters for tuning SLURM resource limits at individual stages of the pipeline.  Without these controls, canu tries to use all available nodes, which is neither kosher nor particularly beneficial on a large, shared cluster.

In our experience, a few hundred cores have provided more than adequate performance for the CPU-bound steps in large genome assemblies.  A few dozen have worked fine for the I/O-intensive steps.

We took what appeared to be the least invasive approach, utilizing SLURM's array job limiting capabilities.

I suspect that other popular schedulers such as PBS have similar features to which these changes could be easily adapted.

It seems to me that a scheduler-agnostic approach would be more difficult and invasive, though.

Regards,

    Jason