### PR TITLE
Fixed typo in fast execution message

### DIFF
--- a/src/pipelines/canu/Execution.pm
+++ b/src/pipelines/canu/Execution.pm
@@ -112,7 +112,7 @@ sub logFinished ($$) {
 
     push @fast, "lickety-split";
     push @fast, "fast as lightning";
-    push @fast, "fuirously fast";
+    push @fast, "furiously fast";
     push @fast, "like a bat out of hell";
     push @fast, "in the blink of an eye";
 


### PR DESCRIPTION
Saw this typo when running an assembly with canu.

-- Finished on Mon Sep 10 09:14:15 2018 (**fuirously fast**) with 26.399 GB free disk space