### PR TITLE
Fix syntax error and add support for wtdbg2 output (gzipped by default)

### DIFF
--- a/src/pipelines/canu/Unitig.pm
+++ b/src/pipelines/canu/Unitig.pm
@@ -272,18 +272,17 @@ sub unitig ($) {
         print F " -t "              . getGlobal("dbgThreads") . " \\\n"   if (defined(getGlobal("dbgThreads")));
         print F " "                 . getGlobal("dbgOptions") . " \\\n"   if (defined(getGlobal("dbgOptions")));
         print F " > ./unitigger.err 2>&1 \n";
-        print F "if [ ! -s ./$asm.ctg.lay ]; then \n";
+        print F "if [ ! -s ./$asm.ctg.lay -o ! -s ./$asm.ctg.lay.gz ]; then \n"; # wtdbg2 outputs gzipped
         print F "  echo Failed to run wtdbg.\n";
         print F "  exit 1\n";
         print F "fi\n";
         print F "\n";
         print F "\n";
-        print F " \$bin/wtdbgConvert -o ./$asm -S ../../$asm.seqStore $asm.ctg.lay \\\n";
-        print F "  && \\\n";
-        print F "  cp -r ./$asm.ctgStore ../$asm.utgStore \\\n";
-        print F "  && \\\n";
-        print F "  mv ./$asm.ctgStore ../$asm.ctgStore\n";
-        print F "fi\n";
+        print F "\$bin/wtdbgConvert -o ./$asm -S ../../$asm.seqStore $asm.ctg.lay \\\n";
+        print F "&& \\\n";
+        print F "cp -r ./$asm.ctgStore ../$asm.utgStore \\\n";
+        print F "&& \\\n";
+        print F "mv ./$asm.ctgStore ../$asm.ctgStore\n";
 
     } else {
         caFailure("unknown unitigger '" . getGlobal("unitigger") . "'", undef);


### PR DESCRIPTION
Hi, I fixed a syntax error (removed a lone `fi` without `if`), and since I was using a linked-in binary of wtdbg2 for unitigging, also added support for its gzipped .ctg.lay output file. The old version was not checking for the .gz extension.