### PR TITLE
drop two non-existent submodules being exported in 

### DIFF
--- a/src/pipelines/canu/Meryl.pm
+++ b/src/pipelines/canu/Meryl.pm
@@ -40,7 +40,7 @@ package canu::Meryl;
 require Exporter;
 
 @ISA    = qw(Exporter);
-@EXPORT = qw(merylConfigure merylCountCheck merylProcessCheck merylSubtract merylFinishSubtraction);
+@EXPORT = qw(merylConfigure merylCountCheck merylProcessCheck);
 
 use strict;
 use warnings "all";


### PR DESCRIPTION
`src/pipelines/canu/Meryl.pm`

I suspect they are moved to `HaplotypeReads.pm`.