### PR TITLE
Adds an interactive Jupyter notebook example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Canu is a hierarchical assembly pipeline which runs in four steps:
 
 ## Learn:
 
-The [quick start](http://canu.readthedocs.io/en/latest/quick-start.html) will get you assembling quickly, while the [tutorial](http://canu.readthedocs.io/en/latest/tutorial.html) explains things in more detail.
+The [quick start](http://canu.readthedocs.io/en/latest/quick-start.html) and its corresponding [interactive Jupyter notebook](https://biotutorials.org/canu) will get you assembling quickly, while the [tutorial](http://canu.readthedocs.io/en/latest/tutorial.html) explains things in more detail.
 
 ## Run:
 


### PR DESCRIPTION
I wrote a notebook based on the [Canu quick start](https://canu.readthedocs.io/en/latest/quick-start.html); this PR adds a link to an [interactive Jupyter notebook](https://biotutorials.org/canu) in the README.

I [opened a similar PR for MEGAHIT](https://github.com/voutcn/megahit/pull/350) after building something similar to help our collaborators get started, and Canu was the next requested tool! It seems to have been helpful so far for MEGAHIT, and my hope is that it will similarly be a way to lower the bar for users to get started with Canu (you can skip the install, getting access to HPC servers, and demo data download while trying out Canu).

To make this work, I built a small service that spins up a unique JupyterLab session for each user and uses our HPC servers for the compute-intensive parts. It's free, can run the simple PacBio assembly in about 20 minutes, and my hope is that it helps researchers get started with Canu more quickly.

Feel free to merge this as is, or I'm happy to modify it as you'd like! Here's a short video showing the notebook spawning in real time:


https://user-images.githubusercontent.com/10551613/220457953-05b65069-7641-461a-955f-8a28197b85e8.mov

